### PR TITLE
add (int) in getDefaultParameters()

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -160,8 +160,8 @@ class Client
     public function getDefaultParameters(): array
     {
         return [
-            'partner_id' => $this->partnerId,
-            'shopid' => $this->shopId,
+            'partner_id' => (int) $this->partnerId,
+            'shopid' => (int) $this->shopId,
             'timestamp' => time(), // Put the current UNIX timestamp when making a request
         ];
     }


### PR DESCRIPTION
To take the default parameter, int is required. If not :
partner_id and shopid will be strings. That will cause an error